### PR TITLE
feat(re-add/fix): custom arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ You can join our [discord server](https://discord.gg/5Xh2W87egW) for commits, ch
 -   Custom Splash animations from [this PR](https://github.com/Vencord/Vesktop/pull/355)
 -   Tray Customization & Voice detection and Badge from [this PR](https://github.com/Vencord/Vesktop/pull/517)
 -   Global Keybind to Toggle voice status from [this PR](https://github.com/Vencord/Vesktop/pull/609)
+-   Custom Arguments from [this PR](https://github.com/Equicord/Equibop/pull/46)
 -   Remove (#) title prefix when Notification Badge option is toggled from [this PR](https://github.com/Vencord/Vesktop/pull/686)
 
 **Linux Note**:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -39,7 +39,7 @@ if (IS_DEV) {
 process.env.EQUICORD_USER_DATA_DIR = DATA_DIR;
 
 function init() {
-    const { disableSmoothScroll, hardwareAcceleration, splashAnimationPath } = Settings.store;
+    const { disableSmoothScroll, hardwareAcceleration, splashAnimationPath, arguments: args } = Settings.store;
 
     const enabledFeatures = app.commandLine.getSwitchValue("enable-features").split(",");
     const disabledFeatures = app.commandLine.getSwitchValue("disable-features").split(",");
@@ -63,7 +63,10 @@ function init() {
     if (process.platform === "win32") {
         disabledFeatures.push("CalculateNativeWinOcclusion");
     }
-
+    if (args) {
+        app.commandLine.appendArgument(args);
+        console.log("Running with additional arguments:", args);
+    }
     // work around chrome 66 disabling autoplay by default
     app.commandLine.appendSwitch("autoplay-policy", "no-user-gesture-required");
     // WinRetrieveSuggestionsOnlyOnDemand: Work around electron 13 bug w/ async spellchecking on Windows.

--- a/src/renderer/components/settings/Arguments.tsx
+++ b/src/renderer/components/settings/Arguments.tsx
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0
+ * Vesktop, a desktop app aiming to give you a snappier Discord Experience
+ * Copyright (c) 2023 Vendicated and Vencord contributors
+ */
+
+import { Margins, Modals, ModalSize, openModal } from "@vencord/types/utils";
+import { Button, Forms, TextInput } from "@vencord/types/webpack/common";
+import { useSettings } from "renderer/settings";
+import { isLinux } from "renderer/utils";
+
+import { SettingsComponent } from "./Settings";
+
+export const Arguments: SettingsComponent = ({ settings }) => {
+    if (!isLinux) return null;
+
+    const settingsStore = useSettings();
+
+    const openTextModal = () => {
+        let Arguments = settingsStore.arguments;
+
+        openModal(props => (
+            <Modals.ModalRoot {...props} size={ModalSize.SMALL}>
+                <Modals.ModalHeader className="vcd-custom-tray-header">
+                    <Forms.FormTitle tag="h2">Configure Arguments</Forms.FormTitle>
+                    <Modals.ModalCloseButton onClick={props.onClose} />
+                </Modals.ModalHeader>
+                <Modals.ModalContent>
+                    <TextInput
+                        type="text"
+                        defaultValue={Arguments}
+                        onChange={value => (Arguments = value)}
+                        placeholder="--ozone-platform=auto"
+                    />
+                </Modals.ModalContent>
+                <Modals.ModalFooter>
+                    <Button
+                        style={{ marginLeft: "10px" }}
+                        color={Button.Colors.RED}
+                        onClick={() => {
+                            settingsStore.arguments = Arguments;
+                            props.onClose();
+                        }}
+                    >
+                        Save
+                    </Button>
+                    <Button onClick={props.onClose}>Close</Button>
+                </Modals.ModalFooter>
+            </Modals.ModalRoot>
+        ));
+    };
+
+    return (
+        <Forms.FormSection>
+            <div className="vcd-tray-settings">
+                <div className="vcd-tray-container">
+                    <div className="vcd-tray-settings-labels">
+                        <Forms.FormTitle tag="h3">Arguments</Forms.FormTitle>
+                        <Forms.FormText>Enter arguments to pass to Discord</Forms.FormText>
+                    </div>
+                    <Button onClick={openTextModal}>Configure</Button>
+                </div>
+                <Forms.FormDivider className={Margins.top20 + " " + Margins.bottom20} />
+            </div>
+        </Forms.FormSection>
+    );
+};

--- a/src/renderer/components/settings/Arguments.tsx
+++ b/src/renderer/components/settings/Arguments.tsx
@@ -7,13 +7,10 @@
 import { Margins, Modals, ModalSize, openModal } from "@vencord/types/utils";
 import { Button, Forms, TextInput } from "@vencord/types/webpack/common";
 import { useSettings } from "renderer/settings";
-import { isLinux } from "renderer/utils";
 
 import { SettingsComponent } from "./Settings";
 
 export const Arguments: SettingsComponent = ({ settings }) => {
-    if (!isLinux) return null;
-
     const settingsStore = useSettings();
 
     const openTextModal = () => {

--- a/src/renderer/components/settings/Arguments.tsx
+++ b/src/renderer/components/settings/Arguments.tsx
@@ -27,7 +27,7 @@ export const Arguments: SettingsComponent = ({ settings }) => {
                         type="text"
                         defaultValue={Arguments}
                         onChange={value => (Arguments = value)}
-                        placeholder="--ozone-platform=auto"
+                        placeholder="--force_high_performance_gpu"
                     />
                 </Modals.ModalContent>
                 <Modals.ModalFooter>

--- a/src/renderer/components/settings/Settings.tsx
+++ b/src/renderer/components/settings/Settings.tsx
@@ -11,6 +11,7 @@ import { ComponentType } from "react";
 import { Settings, useSettings } from "renderer/settings";
 import { isLinux, isMac, isWindows } from "renderer/utils";
 
+import { Arguments } from "./Arguments";
 import { AutoStartToggle } from "./AutoStartToggle";
 import { CustomSplashAnimation } from "./CustomSplashAnimation";
 import { DiscordBranchPicker } from "./DiscordBranchPicker";
@@ -97,6 +98,7 @@ const SettingsOptions: Record<string, Array<BooleanSetting | SettingsComponent>>
         }
     ],
     Behaviour: [
+        Arguments,
         {
             key: "disableMinSize",
             title: "Disable minimum window size",

--- a/src/shared/settings.d.ts
+++ b/src/shared/settings.d.ts
@@ -30,6 +30,7 @@ export interface Settings {
     disableMinSize?: boolean;
     clickTrayToShowHide?: boolean;
     customTitleBar?: boolean;
+    arguments?: string;
 
     splashTheming?: boolean;
     splashColor?: string;


### PR DESCRIPTION
## Custom Arguments
This is useful for people that might want to use flags to boost their performance on Equibop or use some extra features without needing to type it the argument out every single time and instead apply it with a good looking modal.

![image](https://github.com/user-attachments/assets/2afbbd84-124b-4bac-ba06-b073cd04f70d)

note: this PR will not make something like `--ozone-platform=auto` work since those need to be injected before launch and electron limitations don't allow to so. 