### PR TITLE
Fix tray icon when leaving a call with notification badges off

### DIFF
--- a/src/renderer/patches/tray.ts
+++ b/src/renderer/patches/tray.ts
@@ -6,6 +6,7 @@
 
 import { onceReady } from "@equicord/types/webpack";
 import { FluxDispatcher, MediaEngineStore, UserStore } from "@equicord/types/webpack/common";
+import { Settings } from "renderer/settings";
 
 import { setBadge } from "../appBadge";
 
@@ -83,7 +84,8 @@ onceReady.then(() => {
                 isInCall = false;
                 currentVariant = null;
                 VesktopNative.tray.setVoiceCallState(false);
-                setBadge();
+                if (Settings.store.appBadge) setBadge();
+                else VesktopNative.app.setBadgeCount(0);
             }
         }
     };


### PR DESCRIPTION
the tray icon normally keeps its last voice state icon when leaving a call unless Notification Badges is enabled, but this fixes that.