### PR TITLE
Downgrade electron to 39.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "@types/node": "^25.3.0",
         "@types/react": "19.2.9",
         "dotenv": "^17.3.1",
-        "electron": "^40.6.0",
+        "electron": "^39.5.2",
         "electron-builder": "^26.8.1",
         "esbuild": "^0.27.3",
         "eslint": "^10.0.0",


### PR DESCRIPTION
There`s no prebuilt electron40 on arch repos, and the app works fine on the base electron package from extras/

I`m unsure if this will do the job, but will be really nice to have this, i hate removing the bin package every time