### PR TITLE
Add `desktopName` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "name": "equibop",
+    "desktopName": "equibop",
     "version": "3.2.0",
     "private": true,
     "description": "Equibop is a custom Discord desktop app",


### PR DESCRIPTION
[Since Electron 41, the WM class is set differently.](https://github.com/electron/electron/pull/49988/changes/eefeaa7e17d90e23d2365a7e54c16a845062c7d1) Instead of using `name` from `package.json`, it now looks at `desktopName` with a fallback to executable name (which is usually `electron`, because `equibop` is a shell script wrapper)

WM class is what you see in `hyprctl clients` or similar commands:
```
Window 559ff5695040 -> Discord:
        mapped: 1
        hidden: 0
        at: 11,60
        size: 1898,1009
        workspace: 3 (3)
        floating: 0
        monitor: 0
        class: electron      # <- here
        title: Discord
        initialClass: electron
        initialTitle: Discord
        pid: 209204
        xwayland: 0
        pinned: 0
        fullscreen: 0
        fullscreenClient: 0
        overFullscreen: 0
        grouped: 0
        tags:
        swallowing: 0
        focusHistoryID: 9
        inhibitingIdle: 0
        xdgTag:
        xdgDescription:
        contentType: none
        stableID: 18000065
```

See also https://github.com/NixOS/nixpkgs/issues/505078

P.S. This is not a Nix-specific issue, Flatpak version is also affected