### PR TITLE
fix transparency on mac

### DIFF
--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -361,7 +361,7 @@ function buildBrowserWindowOptions(): BrowserWindowConstructorOptions {
         ...getWindowBoundsOptions()
     };
 
-    if (transparent) {
+    if (transparent && process.platform !== "darwin") {
         options.transparent = true;
         options.backgroundColor = "#00000000";
     }
@@ -383,8 +383,10 @@ function buildBrowserWindowOptions(): BrowserWindowConstructorOptions {
         options.titleBarStyle = "hidden";
         options.trafficLightPosition = { x: 10, y: 10 };
 
-        if (macosVibrancyStyle) {
-            options.vibrancy = macosVibrancyStyle;
+        if (transparent) {
+            options.titleBarStyle = "hiddenInset";
+            options.vibrancy = macosVibrancyStyle || "sidebar";
+            options.visualEffectState = "active";
             options.backgroundColor = "#00000000";
         }
     }


### PR DESCRIPTION
fixes transparency on mac by enabling vibrancy instead of having an unusable completely transparent window (can still be configured via the macosVibrancyStyle settings key but it was removed upstream for some reason)