### PR TITLE
Fix: Broken arrpc display with some rpc clients

### DIFF
--- a/src/renderer/arrpc.ts
+++ b/src/renderer/arrpc.ts
@@ -38,6 +38,7 @@ interface Activity {
     name?: string;
     details?: string;
     state?: string;
+    type?: number;
     assets?: ActivityAssets;
     timestamps?: {
         start?: number;
@@ -108,6 +109,8 @@ async function handleActivityEvent(data: ActivityEvent) {
     }
 
     if (activity) {
+        if (activity.type == null) activity.type = 0;
+
         const { assets } = activity;
         if (assets?.large_image) assets.large_image = await lookupAsset(activity.application_id, assets.large_image);
         if (assets?.small_image) assets.small_image = await lookupAsset(activity.application_id, assets.small_image);


### PR DESCRIPTION
Discord's native RPC server treats missing types as PLAYING (0). Some RPC clients omit it, and Discord won't render "Playing XYZ" without the default value.

This is most likely the same issue as in https://github.com/Equicord/Equicord/issues/1069. I'm unsure how exactly Equicord integrates with Equibop on this regard so maybe this belongs into Equicord instead.

This was tested on 5d72ea5 of Equibop with [3f52950](https://github.com/Equicord/Equicord/commit/3f52950b3985350a1b80bad9d50f76ddfa5b1428) of Equicore using [Discord Rich Presence](https://plugins.jetbrains.com/plugin/24027-discord-rich-presence)

<table>
<tr>
<td align="center">

### Before
<img width="322" height="718" alt="2026-05-19-194020_hyprshot" src="https://github.com/user-attachments/assets/7db00853-296d-4f76-b517-ea25e82103c4" />

</td>
<td align="center">

### After
<img width="322" height="742" alt="2026-05-19-194121_hyprshot" src="https://github.com/user-attachments/assets/3e7b64a6-d349-466c-b27d-f37e793e6347" />

</td>
</tr>
</table>