### PR TITLE
fix: correctly handle enable/disable feature flags from launch args modal

### DIFF
--- a/src/main/startup.ts
+++ b/src/main/startup.ts
@@ -78,7 +78,13 @@ function init() {
                 if (eqIndex !== -1) {
                     const key = cleanArg.slice(2, eqIndex);
                     const value = cleanArg.slice(eqIndex + 1);
-                    app.commandLine.appendSwitch(key, value);
+                    if (key === "enable-features") {
+                        value.split(",").forEach(feature => enabledFeatures.add(feature));
+                    } else if (key === "disable-features") {
+                        value.split(",").forEach(feature => disabledFeatures.add(feature));
+                    } else {
+                        app.commandLine.appendSwitch(key, value);
+                    }
                 } else {
                     app.commandLine.appendSwitch(cleanArg.slice(2));
                 }


### PR DESCRIPTION
The `enable-features` and `disable-features` arguments are a special case which can only be set once. Other parts of startup already handle this by adding to their respective sets, however args added via the launch arguments modal don't. This PR remedies this.