### PR TITLE
fix: app badge showing -1

### DIFF
--- a/src/main/appBadge.ts
+++ b/src/main/appBadge.ts
@@ -50,7 +50,7 @@ export function setBadgeCount(count: number) {
 
     switch (process.platform) {
         case "linux":
-            // if (count === -1) count = 0;
+            if (count === -1) count = 0;
             updateUnityLauncherCount(count);
             break;
         case "darwin":


### PR DESCRIPTION
App badge shows -1 when there are no pings
Uncommented one line to match Vesktop upstream behavior

Fixes #126 